### PR TITLE
Update ARM support

### DIFF
--- a/include/sanitizer/config.h
+++ b/include/sanitizer/config.h
@@ -2,9 +2,21 @@
 
 /* This file defines default values for all sanitizer functionality */
 
+/* Allow the user to define SANITIZER_CONFIG_BACKTRACE_ENABLE
+ * themselves if it exists
+ */
 #ifndef SANITIZER_CONFIG_BACKTRACE_ENABLE
+#if defined(__linux__) || defined(__APPLE__)
+/* If there's a reasonable chance backtrace exists, enable it by default */
+#define SANITIZER_CONFIG_BACKTRACE_ENABLE (1)
+#else
 #define SANITIZER_CONFIG_BACKTRACE_ENABLE (0)
-#define SANITIZER_CONFIG_BACKTRACE_DEFAULT (0)
+#endif /* __linux__ || __APPLE__ */
+
+#if SANITIZER_CONFIG_BACKTRACE_ENABLE == 1
+#define SANITIZER_CONFIG_BACKTRACE_RUNTIME_DEFAULT_STATE (0)
 #define SANITIZER_CONFIG_BACKTRACE_START_DEPTH (2)
 #define SANITIZER_CONFIG_BACKTRACE_DEPTH (1024)
 #endif
+
+#endif /* SANITIZER_CONFIG_BACKTRACE_OVERRIDE */

--- a/include/sanitizer/platform.h
+++ b/include/sanitizer/platform.h
@@ -11,7 +11,10 @@ typedef sys_uptr sys_uhwptr;
 typedef sys_uptr ValuePtr;
 
 #if defined(__x86_64__) || defined(__x86_32__) || defined(__i386)
-typedef long double floatmax_t;
+
+// Long doubles shouldn't exist, so let's pretend they don't
+typedef double floatmax_t;
+
 #define SIntFormat "%li"
 #define UIntFormat "%lu"
 #define FloatFormat "%lE"

--- a/include/sanitizer/platform.h
+++ b/include/sanitizer/platform.h
@@ -10,14 +10,14 @@ typedef signed long sys_sptr;
 typedef sys_uptr sys_uhwptr;
 typedef sys_uptr ValuePtr;
 
-typedef double floatmax_t;
-
 #if defined(__x86_64__) || defined(__x86_32__) || defined(__i386)
+typedef long double floatmax_t;
 #define SIntFormat "%li"
 #define UIntFormat "%lu"
 #define FloatFormat "%lE"
 #define LineFormat "%u"
 #elif defined(__ARM_ARCH_7R__)
+typedef double floatmax_t;
 #define SIntFormat "%llu"
 #define UIntFormat "%llu"
 #define FloatFormat "%lE"

--- a/src/common/backtrace.c
+++ b/src/common/backtrace.c
@@ -13,8 +13,7 @@ EXTERN_C bool ATTR_ALIAS("__sanitizer_backtrace_enabled_impl")
 EXTERN_C void ATTR_ALIAS("__sanitizer_print_backtrace_impl")
     __sanitizer_print_backtrace(void);
 
-#if defined(SANITIZER_CONFIG_BACKTRACE_ENABLE) &&                              \
-    (SANITIZER_CONFIG_BACKTRACE_ENABLE != 0)
+#if SANITIZER_CONFIG_BACKTRACE_ENABLE == 1
 
 #include <errno.h>
 #include <stdlib.h>
@@ -32,7 +31,7 @@ volatile atomic_bool __sanitizer_backtrace_flag;
 
 void ATTR_CONSTRUCTOR __sanitizer_backtrace_init(void) {
   __sanitizer_backtrace_flag =
-      ATOMIC_VAR_INIT(SANITIZER_CONFIG_BACKTRACE_DEFAULT);
+      ATOMIC_VAR_INIT(SANITIZER_CONFIG_BACKTRACE_RUNTIME_DEFAULT_STATE);
 }
 
 EXTERN_C void __sanitizer_enable_backtrace_impl(bool enable) {
@@ -89,4 +88,4 @@ EXTERN_C bool __sanitizer_backtrace_enabled_impl(void) { return false; }
 EXTERN_C void __sanitizer_print_backtrace_impl(void) { return; }
 
 #pragma GCC diagnostic pop
-#endif
+#endif /* SANITIZER_CONFIG_BACKTRACE_ENABLE == 1 */


### PR DESCRIPTION
This PR fixes a few bugs discovered when testing the library on ARM, including the use of uintmax_t instead of intmax_t for signed functions. It also reworks the backtrace macros a bit and adds support for ARM v7 r. The code should be portable to all armv7, but has not been tested against other arm platforms.