### PR TITLE
Implement missing UBSAN handler APIs

### DIFF
--- a/src/ubsan/ubsan_api.h
+++ b/src/ubsan/ubsan_api.h
@@ -49,6 +49,11 @@ RECOVERABLE(float_cast_overflow, void *Data, ValuePtr From)
 UNRECOVERABLE(builtin_unreachable, UnreachableData *Data)
 UNRECOVERABLE(missing_return, UnreachableData *Data)
 
+RECOVERABLE(cfi_check_fail, CFICheckFailData *Data, ValuePtr Value,
+            sys_uptr ValidVtable)
+UNRECOVERABLE(cfi_bad_type, CFICheckFailData *Data, ValuePtr Vtable,
+              bool ValidVtable)
+
 typedef enum UB_Type {
   Err_Unknown,
   Err_NullPtrUse,

--- a/src/ubsan/ubsan_api.h
+++ b/src/ubsan/ubsan_api.h
@@ -14,7 +14,7 @@ RECOVERABLE(alignment_assumption, AlignmentAssumptionData *Data,
             ValuePtr Pointer, ValuePtr Alignment, ValuePtr Offset)
 
 // Integer arithmetic overflows
-RECOVERABLE(addition_overflow, OverflowData *Data, ValuePtr Lhs, ValuePtr Rhs)
+RECOVERABLE(add_overflow, OverflowData *Data, ValuePtr Lhs, ValuePtr Rhs)
 RECOVERABLE(sub_overflow, OverflowData *Data, ValuePtr Lhs, ValuePtr Rhs)
 RECOVERABLE(mul_overflow, OverflowData *Data, ValuePtr Lhs, ValuePtr Rhs)
 RECOVERABLE(negate_overflow, OverflowData *Data, ValuePtr Val)

--- a/src/ubsan/ubsan_api.h
+++ b/src/ubsan/ubsan_api.h
@@ -57,6 +57,9 @@ UNRECOVERABLE(cfi_bad_type, CFICheckFailData *Data, ValuePtr Vtable,
 RECOVERABLE(function_type_mismatch_v1, FunctionTypeMismatchData *Data,
             ValuePtr Function, ValuePtr calleeRTTI, ValuePtr fnRTTI)
 
+RECOVERABLE(dynamic_type_cache_miss, DynamicTypeCacheMissData *Data,
+            ValuePtr Ptr, ValuePtr Hash)
+
 typedef enum UB_Type {
   Err_Unknown,
   Err_NullPtrUse,

--- a/src/ubsan/ubsan_api.h
+++ b/src/ubsan/ubsan_api.h
@@ -43,16 +43,19 @@ RECOVERABLE(nullability_arg, NonNullArgData *Data)
 RECOVERABLE(pointer_overflow, PointerOverflowData *Data, ValuePtr Base,
             ValuePtr Result)
 
-// Don't handle until the version compatibility issues are sorted
 RECOVERABLE(float_cast_overflow, void *Data, ValuePtr From)
 
 UNRECOVERABLE(builtin_unreachable, UnreachableData *Data)
 UNRECOVERABLE(missing_return, UnreachableData *Data)
 
+/* C++ APIs that are not fully implemented */
 RECOVERABLE(cfi_check_fail, CFICheckFailData *Data, ValuePtr Value,
             sys_uptr ValidVtable)
 UNRECOVERABLE(cfi_bad_type, CFICheckFailData *Data, ValuePtr Vtable,
               bool ValidVtable)
+
+RECOVERABLE(function_type_mismatch_v1, FunctionTypeMismatchData *Data,
+            ValuePtr Function, ValuePtr calleeRTTI, ValuePtr fnRTTI)
 
 typedef enum UB_Type {
   Err_Unknown,

--- a/src/ubsan/ubsan_handlers.c
+++ b/src/ubsan/ubsan_handlers.c
@@ -336,6 +336,17 @@ static void HandleFunctionTypeMismatch(FunctionTypeMismatchData *Data,
             calleeRTTI, fnRTTI);
 }
 
+static void HandleDynamicTypeCacheMiss(DynamicTypeCacheMissData *Data,
+                                       ValuePtr Ptr, ValuePtr Hash) {
+
+  __sanitizer_print_backtrace();
+
+  EmitError(
+      &Data->Loc,
+      "%s address 0x%lx does not point to an object of the correct type\n",
+      TypeCheckKinds[Data->Kind], Ptr);
+}
+
 #pragma GCC diagnostic pop
 
 /******************************************************************************
@@ -605,6 +616,17 @@ void __ubsan_handle_function_type_mismatch_v1_abort(
     FunctionTypeMismatchData *Data, ValuePtr Val, ValuePtr calleeRTTI,
     ValuePtr fnRTTI) {
   HandleFunctionTypeMismatch(Data, Val, calleeRTTI, fnRTTI);
+  Die();
+}
+
+void __ubsan_handle_dynamic_type_cache_miss(DynamicTypeCacheMissData *Data,
+                                            ValuePtr Ptr, ValuePtr Hash) {
+  HandleDynamicTypeCacheMiss(Data, Ptr, Hash);
+}
+
+void __ubsan_handle_dynamic_type_cache_miss_abort(
+    DynamicTypeCacheMissData *Data, ValuePtr Ptr, ValuePtr Hash) {
+  HandleDynamicTypeCacheMiss(Data, Ptr, Hash);
   Die();
 }
 

--- a/src/ubsan/ubsan_types.h
+++ b/src/ubsan/ubsan_types.h
@@ -100,3 +100,10 @@ typedef struct {
   SourceLocation Loc;
   REFERENCE(const TypeDescriptor) Type;
 } FunctionTypeMismatchData;
+
+typedef struct {
+  SourceLocation Loc;
+  REFERENCE(const TypeDescriptor) Type;
+  void *TypeInfo;
+  unsigned char Kind;
+} DynamicTypeCacheMissData;

--- a/src/ubsan/ubsan_types.h
+++ b/src/ubsan/ubsan_types.h
@@ -95,3 +95,8 @@ typedef struct {
   SourceLocation Loc;
   REFERENCE(const TypeDescriptor) Type;
 } CFICheckFailData;
+
+typedef struct {
+  SourceLocation Loc;
+  REFERENCE(const TypeDescriptor) Type;
+} FunctionTypeMismatchData;


### PR DESCRIPTION
This PR adds the remaining missing handler APIs present in LLVM's ubsan. The C++-specific APIs are implemented mainly as stubs, but return the information they have that doesn't require parsing RTTI. The other functions were already implemented, but typos prevented them from being visible.

Fixes #3