### PR TITLE
Remove unncessary includes

### DIFF
--- a/src/common/backtrace.c
+++ b/src/common/backtrace.c
@@ -1,10 +1,6 @@
-#include "backtrace.h"
-#include <stdatomic.h>
-#include <stdbool.h>
+#include <sanitizer/config.h>
 
-#ifdef __STDC_NO_ATOMICS__
-#error "Atomics not available on target platform"
-#endif
+#include "backtrace.h"
 
 EXTERN_C void ATTR_ALIAS("__sanitizer_enable_backtrace_impl")
     __sanitizer_enable_backtrace(bool enable);
@@ -15,17 +11,18 @@ EXTERN_C void ATTR_ALIAS("__sanitizer_print_backtrace_impl")
 
 #if SANITIZER_CONFIG_BACKTRACE_ENABLE == 1
 
-#include <errno.h>
+#include <execinfo.h>
+
+#include <stdatomic.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <execinfo.h>
-#include <unistd.h>
-
 #include "logger.h"
-#include <sanitizer/platform.h>
 
-#include <stdio.h>
+#ifdef __STDC_NO_ATOMICS__
+#error "Atomics not available on target platform"
+#endif
 
 volatile atomic_bool __sanitizer_backtrace_flag;
 

--- a/src/common/backtrace.h
+++ b/src/common/backtrace.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <sanitizer/config.h>
 #include <sanitizer/interface_utils.h>
 #include <stdbool.h>
 

--- a/src/common/die.c
+++ b/src/common/die.c
@@ -1,13 +1,13 @@
 #include "die.h"
-#include <stdio.h>
-#include <stdlib.h>
+#include <sanitizer/config.h>
 
-#define EXIT_FAILURE_CODE (1)
-
-// Declare our alias
 EXTERN_C void ATTR_NORETURN ATTR_ALIAS("__sanitizer_die_impl") Die(void);
 
 #if SANITIZER_CONFIG_DIE_ENABLE == 1
+
+#include <stdlib.h>
+
+#define EXIT_FAILURE_CODE (1)
 
 EXTERN_C void ATTR_NORETURN __sanitizer_die_impl(void) {
   exit(EXIT_FAILURE_CODE);

--- a/src/common/die.h
+++ b/src/common/die.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <sanitizer/config.h>
 #include <sanitizer/interface_utils.h>
 
 EXTERN_C void ATTR_NORETURN Die(void);

--- a/src/common/logger.c
+++ b/src/common/logger.c
@@ -1,5 +1,4 @@
-#include <stdarg.h>
-#include <stdio.h>
+#include <sanitizer/config.h>
 
 #include "logger.h"
 
@@ -12,6 +11,9 @@ ATTR_ALIAS("__sanitizer_log_printf_impl") int __sanitizer_log_printf(
     LogLevel Level, const char *Format, ...);
 
 #if SANITIZER_CONFIG_LOGGER_ENABLE == 1
+
+#include <stdarg.h>
+#include <stdio.h>
 
 static const char *LevelToStr(LogLevel Level) {
   switch (Level) {

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <sanitizer/config.h>
 #include <sanitizer/interface_utils.h>
 
 typedef enum { LOG_SILENT, LOG_ERROR, LOG_FATAL, LOG_UNKNOWN } LogLevel;


### PR DESCRIPTION
Also cleaned up issues with dependencies for macro config options still being required even if the selected option wasn't being built. This was especially prevalent in backtrace.