### PR TITLE
Add integration documentation and an example application

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,23 @@ The following options control sanitizer functionality:
   * This option depends on `<stdatomic.h>` and `__attribute__((constructor))` because callstack printing can be dynamically enabled or disabled from multiple threads by calling `__sanitizer_enable_backtrace`.
 
 All configuration defaults are set in `include/sanitizer/config.h`
+
+## Integrating libfreesan into your project
+
+  # Before you start
+
+  When integrating libfreesan into your project, first consider whether you can
+  make use of the sanitizers typically provided with your compiler. Toolchain-
+  -supplied sanitizers are guaranteed to have full compatibility with the
+  compiler version they ship with, a guarantee this project inherently cannot
+  make.
+
+  Demonstration projects showing how to integrate available sanitizers are
+  provided in the `demo/` folder.
+
+  # Steps
+
+  1. Compile the relevant sanitizers for your project. The default settings are recommended, but check the documented [configuration options](#configuration-options)
+  2. Compile your application with the appropriate `-fsanitize` settings. Refer to the documentation for your compiler version for details. The latest documentation is available [here for GCC](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html) and [here for clang](https://clang.llvm.org/docs/UsersManual.html).
+  3. Link your application with the sanitizers built in the `lib/` folder. Take care to ensure that the linker correctly picks up the sanitizer libraries we've just built and not any built-in sanitizer runtimes your toolchain may ship with using `ldd` or similar.
+  4. Run your application.

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,0 +1,26 @@
+CFLAGS+=-Werror -Wextra -fsanitize=undefined
+LDFLAGS+=-Wl,-l:libubsan.so.1
+UBSAN_CFLAGS=CFLAGS="-DSANITIZER_CONFIG_BACKTRACE_ENABLE=0 -nodefaultlibs"
+
+DEMO_SRC += ubsan_demo.c
+DEMO_OBJ := $(patsubst %.c, %.o, $(DEMO_SRC))
+
+LIBUBSAN_OBJ = $(../lib/libubsan.so.1)
+.PHONY: clean all run
+
+all: ubsan_demo
+
+run: ubsan_demo
+	LD_LIBRARY_PATH=../lib ./ubsan_demo
+
+clean:
+	rm -f $(DEMO_OBJ) ubsan_demo
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INC_DIR) -c $< -o $@
+
+libubsan: $(LIBUBSAN_OBJ)
+	cd .. && $(UBSAN_CFLAGS) $(MAKE) ubsan
+
+ubsan_demo: $(DEMO_OBJ) libubsan
+	LIBRARY_PATH=$(realpath ../lib) $(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(DEMO_OBJ)

--- a/example/ubsan_demo.c
+++ b/example/ubsan_demo.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int main(int argv, char **argc) {
+  printf("Hello, World!\n");
+
+  int *nullptr = (void *)0x0;
+  *nullptr = 1;
+
+  return 0;
+}


### PR DESCRIPTION
This commit adds an example application demonstrating how to integrate with
the ubsan runtime provided by libfreesan. The demo is not perfectly minimal,
but rather demonstrates a small, semi-realistic build system.

Additionally, higher level documentation has been added to the README so that
goes over the steps to integrate libfreesan into your own applications. It also
ensures people are appropriately warned that they should try to use their
toolchain's sanitizers before they use this project.

Fixes #5