### PR TITLE
Add a (useless) default case to the CfiBadType API to make the compiler happy.

### DIFF
--- a/src/ubsan/ubsan_handlers.c
+++ b/src/ubsan/ubsan_handlers.c
@@ -321,6 +321,7 @@ static void HandleCfiBadType(CFICheckFailData *Data, ValuePtr Vtable,
   case CFITCK_VMFCall:
   case CFITCK_ICall:
   case CFITCK_NVMFCall:
+  default:
     EmitError(&Data->Loc,
               "control flow integrity check failed during %s (vtable address "
               "0x%lx)\n",


### PR DESCRIPTION
Since we already assume the compiler is passing valid objects, this is purely to keep the compiler from complaining when it's using overly strict warnings.

Fixes #21